### PR TITLE
Add notes about exceptions on invalid tokens to both delete READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ This function takes the following options as parameters:
 | `token` | `string` | The token of the file you wish to delete | true     |            |
 | `ct`    | `canceltoken`| An optional cancellation token that can be passed in            | false    | Standard cancellation token |
 
+> **NOTE:** `deleteFile` will only ever either return `true` or throw an exception if the token is invalid
+
 Standard delete:
 
 ```cs


### PR DESCRIPTION
Add note explaining both deletes will throw an exception on invalid token to the README